### PR TITLE
fix: spelling errors

### DIFF
--- a/print/andreashappe.md
+++ b/print/andreashappe.md
@@ -38,7 +38,7 @@ I see two two challenges:
 
 And a bonus one: Don't use Security to Shame People
 
-Typically people can only keep a few things on their mind (3-4 things). Imagine, you're a developer. Those four things are quickly used up: one or two functional requirements, performance, food & coffee, and maybe there's something going on in your personal life. Now, imagine a pen-tester gets to work on the same projects. What's on their mind? security, security, security, coffee. Of course, they will find issues.. and that's okay. We're here to help. An audit is just an opportunity to learn and fix problems before real attackers find them.
+Typically people can only keep a few things on their mind (3-4 things). Imagine, you're a developer. Those four things are quickly used up: one or two functional requirements, performance, food & coffe, and maybe there's something going on in your personal life. Now, imagine a pen-tester gets to work on the same projects. What's on their mind? security, security, security, coffee. Of course, they will find issues.. and that's okay. We're here to help. An audit is just an opportunity to learn and fix problems before real attackers find them.
 
 ## What’s the impact of AI on Open Source development?
 

--- a/print/blyxyas.md
+++ b/print/blyxyas.md
@@ -4,7 +4,7 @@
 > [github.com/blyxyas](https://github.com/blyxyas)  
 > [maintaine.rs/blyxyas](https://maintaine.rs/blyxyas)
 
-I'm Alejandra, one of the people that maintains Clippy[^310], Rust's[^309] official linter. And for this Maintainer Month of May I've come to [opensource.org](https://opensource.org) about some often-overlooked aspects of maintaining a FOSS project, some of my personal story with FOSS, some tips about software security, and how to better help maintainers as a contributor. Strap in because this will be a wild ride!
+I'm Alejandra, one of the people that maintains Clippy[^310], Rust's[^309] official linter. And for this Maintainer Month of May I've come to [opensource.org](https://opensource.org) about some often-overlook aspects of maintaining a FOSS project, some of my personal story with FOSS, some tips about software security, and how to better help maintainers as a contributor. Strap in because this will be a wild ride!
 
 ## Who are you again?
 

--- a/print/derberg.md
+++ b/print/derberg.md
@@ -61,7 +61,7 @@ Personally, I’m also concerned about the threat posed by potentially malicious
 
 Too many contributors use it incorrectly and end up spamming projects. But for me, as an experienced maintainer who can verify AI-generated output, it speeds up my work.
 
-Does this speedup balance out the AI spam? Does it mean nothing has changed? I have no idea. :)
+Does this speed-up balance out the AI spam? Does it mean nothing has changed? I have no idea. :)
 
 \newpage
 


### PR DESCRIPTION
Did a quick AI spell check on all files:

```
⏺ Found 3 spelling mistakes:

  1. print/blyxyas.md:7 and source/blyxyas.md:7
    - "often-overlook" → "often-overlooked"
  2. print/darccio.md:40 and source/darccio.md:40
    - "coffe" → "coffee"
  3. print/derberg.md:50 and source/derberg.md:50
    - "speed-up" could be "speedup" (minor style issue)
```