### PR TITLE
Somewhat fix list in page 38

### DIFF
--- a/docs/blyxyas.html
+++ b/docs/blyxyas.html
@@ -75,6 +75,9 @@
 <li>This is a very simple step, don’t guess about memory leaks, use a heap memory profiler (like <a href="https://github.com/KDE/heaptrack">heaptrack</a>). Don’t guess about memory safety, use a static code analyzer or a language that has memory safety built-in (like Rust). Don’t guess about the origin of something, bisect it in your program (like with <a href="https://git-scm.com/docs/git-bisect"><code>git bisect</code></a>).</li>
 <li>Know your system, the better you know the tools you’re using the better code you’ll produce and the faster you’ll be able to iterate on a design. With this I don’t mean learning a fancy-schmancy IDE or keyboard layout, but learning to make <code>perf</code> valuable, learning to read stack traces, learning to efficiently search throughout your documentation to find that edge case that has been bugging you out all week.</li>
 </ul></li>
+<br>
+<br>
+<br>
 <li><p>Keep learning</p>
 <ul>
 <li>Even if your brain is huge, with the best-quality gray matter in this sector of the galaxy, there have been people before you. The big advantage we have over humans before our time is the collective knowledge that aids us to achieve excellence. Do not let your ego and pride get in the way of making great software, because precisely the way to make great software is knowing who to ask the right question to get the desired results.</li>

--- a/generate_books.py
+++ b/generate_books.py
@@ -305,3 +305,4 @@ run_pandoc(source_dir, output_original_pdf)
 run_pandoc_print(print_dir, output_print_pdf)
 run_pandoc_epub(source_dir, output_epub)
 run_pandoc_html(source_dir, html_dir)
+

--- a/source/blyxyas.md
+++ b/source/blyxyas.md
@@ -60,7 +60,9 @@ Security was this Maintainer Month's topic, so I'll also give out some pieces of
    - This is a very simple step, don't guess about memory leaks, use a heap memory profiler (like [heaptrack]). Don't guess about memory safety, use a static
      code analyzer or a language that has memory safety built-in (like Rust). Don't guess about the origin of something, bisect it in your program (like with [`git bisect`][bisect]).
    - Know your system, the better you know the tools you're using the better code you'll produce and the faster you'll be able to iterate on a design. With this I don't mean learning a fancy-schmancy IDE or keyboard layout, but learning to make `perf` valuable, learning to read stack traces, learning to efficiently search throughout your documentation to find that edge case that has been bugging you out all week.
-
+<br>
+<br>
+<br>
 5. Keep learning
    - Even if your brain is huge, with the best-quality gray matter in this sector of the galaxy, there have been people before you. The big advantage we have over humans before our time is the collective knowledge that aids us to achieve excellence. Do not let your ego and pride get in the way of making great software, because precisely the way to make great software is knowing who to ask the right question to get the desired results.
 


### PR DESCRIPTION
In https://maintaine.rs/maintainers_print.pdf, page 38, the fifth point (*5. Keep learning*) just has a title and the body itself is in the next page.

Also, the final section (*Conclusion*) is only four lines but is being split (into two pages, with the final page being emptier than what'd be comfortable.)